### PR TITLE
Update pci.go to exclude 10de:22ba in GPU filter

### DIFF
--- a/pkg/capacity/pci.go
+++ b/pkg/capacity/pci.go
@@ -306,7 +306,7 @@ func readUint64(path string, bitSize int) (uint64, error) {
 // NOTE: we only also now white list NVIDIA and AMD
 // we skip integrated GPU  normally on slots `0000:00:XX.X` and allow only discrete ones normally on slot `0000:XX:YY.ZZ`
 func GPU(p *PCI) bool {
-	return p.Class == 0x030000 && in(p.Vendor, gpuVendorsWhitelist) && !strings.HasPrefix(p.Slot, "0000:00:")
+	return p.Class == 0x030000 && in(p.Vendor, gpuVendorsWhitelist) && !strings.HasPrefix(p.Slot, "0000:00:") && !strings.HasPrefix(p.Slot, "10de:22ba")
 }
 
 // PCIBridge returns true if p is a PCI bridge


### PR DESCRIPTION
filters out 10de:22ba from the gpu filter