### PR TITLE
fix: cleaning unused tap devices

### DIFF
--- a/pkg/network/cleanup.go
+++ b/pkg/network/cleanup.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+func CleanupUnusedLinks() error {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list network interfaces: %w", err)
+	}
+
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs == nil {
+			continue
+		}
+
+		interfaceName := attrs.Name
+
+		if attrs.OperState == netlink.OperDown && hasNoCarrier(interfaceName) {
+			if err := netlink.LinkDel(link); err != nil {
+				return fmt.Errorf("failed to delete interface %s: %w", interfaceName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func hasNoCarrier(interfaceName string) bool {
+	cmd := exec.Command("ip", "link", "show", interfaceName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(output), "NO-CARRIER")
+}

--- a/pkg/primitives/vm/vm.go
+++ b/pkg/primitives/vm/vm.go
@@ -109,7 +109,6 @@ func (p *Manager) mountVolume(ctx context.Context, wl *gridtypes.WorkloadWithID,
 }
 
 func (p *Manager) mountQsfs(wl *gridtypes.WorkloadWithID, mount zos.MachineMount, vm *pkg.VM) error {
-
 	var info zos.QuatumSafeFSResult
 	if err := wl.Result.Unmarshal(&info); err != nil {
 		return fmt.Errorf("invalid qsfs result '%s': %w", mount.Name, err)
@@ -276,7 +275,6 @@ func (p *Manager) virtualMachineProvisionImpl(ctx context.Context, wl *gridtypes
 		if err = p.prepVirtualMachine(ctx, cloudImage, imageInfo, &machine, &config, &deployment, wl); err != nil {
 			return result, err
 		}
-
 	}
 
 	// - Attach mounts
@@ -351,14 +349,14 @@ func (p *Manager) Deprovision(ctx context.Context, wl *gridtypes.WorkloadWithID)
 	}
 
 	if cfg.Network.Planetary {
-		var tapName string
-		if cfg.Network.Mycelium == nil {
-			// yggdrasil network
-			tapName = wl.ID.Unique("ygg")
-		} else {
-			tapName = wl.ID.Unique("mycelium")
+		tapName := wl.ID.Unique("ygg")
+		if err := network.RemoveTap(ctx, tapName); err != nil {
+			return errors.Wrap(err, "could not clean up tap device")
 		}
+	}
 
+	if cfg.Network.Mycelium != nil {
+		tapName := wl.ID.Unique("mycelium")
 		if err := network.RemoveTap(ctx, tapName); err != nil {
 			return errors.Wrap(err, "could not clean up tap device")
 		}


### PR DESCRIPTION
- add helper method to remove all unused (down+nocarrier) interfaces
- remove both ygg/myc interfaces while deprovisioning vm