### PR TITLE
update zos-api-light to get farmer id from the caller

### DIFF
--- a/pkg/monitord/system.go
+++ b/pkg/monitord/system.go
@@ -13,7 +13,7 @@ import (
 	"github.com/threefoldtech/zosbase/pkg"
 	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
 	"github.com/threefoldtech/zosbase/pkg/kernel"
-  "github.com/threefoldtech/zosbase/pkg/stubs"
+	"github.com/threefoldtech/zosbase/pkg/stubs"
 )
 
 var _ pkg.SystemMonitor = (*systemMonitor)(nil)
@@ -22,7 +22,7 @@ var _ pkg.SystemMonitor = (*systemMonitor)(nil)
 type systemMonitor struct {
 	duration time.Duration
 	node     uint32
-  cl zbus.Client
+	cl       zbus.Client
 }
 
 // NewSystemMonitor creates new system of system monitor
@@ -31,7 +31,7 @@ func NewSystemMonitor(node uint32, duration time.Duration, cl zbus.Client) (pkg.
 		duration = 2 * time.Second
 	}
 
-  return &systemMonitor{duration: duration, node: node, cl: cl}, nil
+	return &systemMonitor{duration: duration, node: node, cl: cl}, nil
 }
 
 func (m *systemMonitor) NodeID() uint32 {
@@ -219,11 +219,11 @@ func (n *systemMonitor) GetNodeFeatures() []pkg.NodeFeature {
 		}
 		feat = append(feat, zosLightFeat...)
 
-    netStub := stubs.NewNetworkerLightStub(n.cl)
-	  config, err := netStub.LoadPublicConfig(context.Background())
-	  if err == nil && config.Domain != "" {
-      feat = append(feat, "gateway-name-proxy")
-		  feat = append(feat, "gateway-fqdn-proxy")
+		netStub := stubs.NewNetworkerLightStub(n.cl)
+		config, err := netStub.LoadPublicConfig(context.Background())
+		if err == nil && config.Domain != "" {
+			feat = append(feat, "gateway-name-proxy")
+			feat = append(feat, "gateway-fqdn-proxy")
 		}
 		return feat
 	}

--- a/pkg/zos_api_light/zos_api.go
+++ b/pkg/zos_api_light/zos_api.go
@@ -1,15 +1,12 @@
 package zosapi
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zosbase/pkg/capacity"
 	"github.com/threefoldtech/zosbase/pkg/diagnostics"
-	"github.com/threefoldtech/zosbase/pkg/environment"
 	"github.com/threefoldtech/zosbase/pkg/stubs"
 )
 
@@ -32,12 +29,7 @@ type ZosAPI struct {
 	inMemCache             *cache.Cache
 }
 
-func NewZosAPI(manager substrate.Manager, client zbus.Client, msgBrokerCon string) (ZosAPI, error) {
-	sub, err := manager.Substrate()
-	if err != nil {
-		return ZosAPI{}, err
-	}
-	defer sub.Close()
+func NewZosAPI(client zbus.Client, farmerID uint32, msgBrokerCon string) (ZosAPI, error) {
 	diagnosticsManager, err := diagnostics.NewDiagnosticsManager(msgBrokerCon, client)
 	if err != nil {
 		return ZosAPI{}, err
@@ -54,16 +46,7 @@ func NewZosAPI(manager substrate.Manager, client zbus.Client, msgBrokerCon strin
 		performanceMonitorStub: stubs.NewPerformanceMonitorStub(client),
 		diagnosticsManager:     diagnosticsManager,
 	}
-	farm, err := sub.GetFarm(uint32(environment.MustGet().FarmID))
-	if err != nil {
-		return ZosAPI{}, fmt.Errorf("failed to get farm: %w", err)
-	}
-
-	farmer, err := sub.GetTwin(uint32(farm.TwinID))
-	if err != nil {
-		return ZosAPI{}, err
-	}
-	api.farmerID = uint32(farmer.ID)
+	api.farmerID = farmerID
 	api.inMemCache = cache.New(cacheDefaultExpiration, cacheDefaultCleanup)
 	return api, nil
 }


### PR DESCRIPTION
update zos-api-light module to get the farmer id from the caller instead of using substrate to get the farm and then the farmer id.