### PR TITLE
extend env relays with zos-config

### DIFF
--- a/pkg/environment/config.go
+++ b/pkg/environment/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	RolloutUpgrade struct {
 		TestFarms []uint32 `json:"test_farms"`
 	} `json:"rollout_upgrade"`
+	RelaysURLs []string `json:"relays_urls"`
 }
 
 // Merge, updates current config with cfg merging and override config

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -190,7 +190,7 @@ var (
 		},
 		relaysURLs: []string{
 			"wss://relay.grid.tf",
-			"wss://relay.02.grid.tf",
+			// "wss://relay.02.grid.tf",
 		},
 		ActivationURL: []string{
 			"https://activation.grid.tf/activation/activate",
@@ -229,20 +229,16 @@ func Get() (Environment, error) {
 	return env, nil
 }
 
-func GetRelaysURLs() (relaysUrls []string, err error) {
-	relaysUrls = MustGet().relaysURLs
-
+func GetRelaysURLs() []string {
 	config, err := GetConfig()
-	// if error happened when getting config from github just ignore and use the one in the env
-	if err != nil {
-		log.Error().Err(err).Msg("failed to get relays urls from zos-config")
-		return
+	if err == nil && len(config.RelaysURLs) > 0 {
+		log.Debug().Msg("using relays urls from zos-config")
+		return config.RelaysURLs
 	}
-	if len(config.RelaysURLs) > 0 {
-		log.Debug().Msg("found relays urls in zos-config")
-		return config.RelaysURLs, nil
-	}
-	return
+
+	log.Debug().Msg("using relays urls from environment")
+	env := MustGet()
+	return env.relaysURLs
 }
 
 // GetSubstrate gets a client to subsrate blockchain

--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -86,7 +86,7 @@ func (h *healthcheckTask) Run(ctx context.Context) (interface{}, error) {
 				}
 
 				if len(errors) != 0 {
-					return fmt.Errorf("failed health check")
+					return fmt.Errorf("failed health check %s", errorsToStrings(errors))
 				}
 
 				return nil

--- a/pkg/perf/healthcheck/network.go
+++ b/pkg/perf/healthcheck/network.go
@@ -30,16 +30,10 @@ func networkCheck(ctx context.Context) []error {
 	services := map[string][]string{
 		"substrate":  env.SubstrateURL,
 		"activation": env.ActivationURL,
+		"relay":      environment.GetRelaysURLs(),
 		"graphql":    env.GraphQL,
 		"hub":        {env.FlistURL},
 		"kyc":        {env.KycURL},
-	}
-
-	relays, err := environment.GetRelaysURLs()
-	if err != nil {
-		errors = append(errors, fmt.Errorf("failed to get relays urls %w", err))
-	} else {
-		services["relays"] = relays
 	}
 
 	for service, instances := range services {


### PR DESCRIPTION
- refactor network health check to require at least one instance of each service to be alive
- fetch relays from zos-config with a fallback to environment 