### PR TITLE
revise mycelium wiring

### DIFF
--- a/pkg/netbase/ifaceutil/ifaceutil.go
+++ b/pkg/netbase/ifaceutil/ifaceutil.go
@@ -1,0 +1,66 @@
+package ifaceutil
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/threefoldtech/zosbase/pkg/network/namespace"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	myceliumPort = "9651"
+)
+
+// GetIPsForIFace retrieves the IP addresses for a given interface name in a specified network namespace.
+// If the namespace name is empty, it retrieves the IP addresses from the host.
+func GetIPsForIFace(iface, nsName string) ([]net.IPNet, error) {
+	getIPs := func() ([]net.IPNet, error) {
+		var results []net.IPNet
+
+		ln, err := netlink.LinkByName(iface)
+		if err != nil {
+			return nil, err
+		}
+
+		ips, err := netlink.AddrList(ln, netlink.FAMILY_V4)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ip := range ips {
+			results = append(results, *ip.IPNet)
+		}
+
+		return results, nil
+	}
+
+	if nsName == "" {
+		return getIPs()
+	}
+
+	netns, err := namespace.GetByName(nsName)
+	if err != nil {
+		return nil, err
+	}
+	defer netns.Close()
+
+	var results []net.IPNet
+	err = netns.Do(func(_ ns.NetNS) error {
+		var getErr error
+		results, getErr = getIPs()
+		return getErr
+	})
+
+	return results, err
+}
+
+// BuildMyceliumPeerURLs constructs a list of Mycelium peer URLs from a list of IP networks.
+func BuildMyceliumPeerURLs(ips []net.IPNet) []string {
+	peers := make([]string, len(ips))
+	for i, ip := range ips {
+		peers[i] = fmt.Sprintf("tcp://%s:%s", ip.IP.String(), myceliumPort)
+	}
+	return peers
+}


### PR DESCRIPTION
### description 
- set mycelium public addresses as peers for private instance, to reduce unnecessary traffic for public nodes in internal communications
- export ndmz constant values for external use
- init netbase/ifaceutil pkg for common utils between net/netlight
- https://github.com/threefoldtech/zos/issues/2443

### verification 
listing peers in the private network namespace

in zos
![image](https://github.com/user-attachments/assets/cf90cfeb-3d7e-439f-9e2e-b85896df5e01)

in zoslight
![image](https://github.com/user-attachments/assets/62912478-5341-4b77-bd40-581aaa16961b)

i couldn't found any differences in the output of `traceroute` before/after this change as mentioned here https://github.com/threefoldtech/zos/issues/2443#issuecomment-2789416534 but maybe due to traceroute itself is not sufficient enough 