### PR TITLE
mycelium messaging integration

### DIFF
--- a/mycelium-openrpc.json
+++ b/mycelium-openrpc.json
@@ -1,0 +1,1093 @@
+{
+  "openrpc": "1.2.3",
+  "info": {
+    "title": "ZOS Mycelium API",
+    "description": "This is an API for interacting with the ZOS nodes over Mycelium.",
+    "version": "1.0.0"
+  },
+  "methods": [
+    {
+      "name": "system.version",
+      "params": [],
+      "result": {
+        "name": "Version",
+        "schema": {
+          "$ref": "#/components/schemas/Version"
+        }
+      }
+    },
+    {
+      "name": "system.hypervisor",
+      "params": [],
+      "result": {
+        "name": "Hypervisor",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "system.diagnostics",
+      "params": [],
+      "result": {
+        "name": "Diagnostics",
+        "schema": {
+          "$ref": "#/components/schemas/Diagnostics"
+        }
+      }
+    },
+    {
+      "name": "system.dmi",
+      "params": [],
+      "result": {
+        "name": "DMI",
+        "schema": {
+          "$ref": "#/components/schemas/DMI"
+        }
+      }
+    },
+    {
+      "name": "system.features",
+      "params": [],
+      "result": {
+        "name": "NodeFeatures",
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "monitor.speed",
+      "params": [],
+      "result": {
+        "name": "SpeedResult",
+        "schema": {
+          "$ref": "#/components/schemas/IperfTaskResult"
+        }
+      }
+    },
+    {
+      "name": "monitor.health",
+      "params": [],
+      "result": {
+        "name": "HealthResult",
+        "schema": {
+          "$ref": "#/components/schemas/HealthTaskResult"
+        }
+      }
+    },
+    {
+      "name": "monitor.publicip",
+      "params": [],
+      "result": {
+        "name": "PublicIpResult",
+        "schema": {
+          "$ref": "#/components/schemas/PublicIpTaskResult"
+        }
+      }
+    },
+    {
+      "name": "monitor.benchmark",
+      "params": [],
+      "result": {
+        "name": "BenchmarkResult",
+        "schema": {
+          "$ref": "#/components/schemas/CpuBenchTaskResult"
+        }
+      }
+    },
+    {
+      "name": "monitor.all",
+      "params": [],
+      "result": {
+        "name": "AllTaskResults",
+        "schema": {
+          "$ref": "#/components/schemas/AllTaskResult"
+        }
+      }
+    },
+    {
+      "name": "network.wg_ports",
+      "params": [],
+      "result": {
+        "name": "WGPorts",
+        "schema": {
+          "$ref": "#/components/schemas/WGPorts"
+        }
+      }
+    },
+    {
+      "name": "network.public_config",
+      "params": [],
+      "result": {
+        "name": "PublicConfig",
+        "schema": {
+          "$ref": "#/components/schemas/PublicConfig"
+        }
+      }
+    },
+    {
+      "name": "network.has_ipv6",
+      "params": [],
+      "result": {
+        "name": "HasIpv6",
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "network.public_ips",
+      "params": [],
+      "result": {
+        "name": "PublicIps",
+        "schema": {
+          "$ref": "#/components/schemas/Ips"
+        }
+      }
+    },
+    {
+      "name": "network.private_ips",
+      "params": [
+        {
+          "name": "network_name",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "PrivateIps",
+        "schema": {
+          "$ref": "#/components/schemas/Ips"
+        }
+      }
+    },
+    {
+      "name": "network.interfaces",
+      "params": [],
+      "result": {
+        "name": "Interface",
+        "schema": {
+          "$ref": "#/components/schemas/Interfaces"
+        }
+      }
+    },
+    {
+      "name": "network.set_public_nic",
+      "params": [
+        {
+          "name": "device",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SetResult",
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "network.get_public_nic",
+      "params": [],
+      "result": {
+        "name": "PublicNIC",
+        "schema": {
+          "$ref": "#/components/schemas/ExitDevice"
+        }
+      }
+    },
+    {
+      "name": "network.admin.interfaces",
+      "params": [],
+      "result": {
+        "name": "Interfaces",
+        "schema": {
+          "$ref": "#/components/schemas/Interfaces"
+        }
+      }
+    },
+    {
+      "name": "deployment.deploy",
+      "params": [
+        {
+          "name": "deployment",
+          "schema": {
+            "$ref": "#/components/schemas/Deployment"
+          }
+        }
+      ],
+      "result": {
+        "name": "createResult",
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "deployment.update",
+      "params": [
+        {
+          "name": "deployment",
+          "schema": {
+            "$ref": "#/components/schemas/Deployment"
+          }
+        }
+      ],
+      "result": {
+        "name": "updateResult",
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "deployment.get",
+      "params": [
+        {
+          "name": "contract_id",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "result": {
+        "name": "Deployment",
+        "schema": {
+          "$ref": "#/components/schemas/Deployment"
+        }
+      }
+    },
+    {
+      "name": "deployment.list",
+      "params": [],
+      "result": {
+        "name": "Deployments",
+        "schema": {
+          "$ref": "#/components/schemas/Deployments"
+        }
+      }
+    },
+    {
+      "name": "deployment.changes",
+      "params": [
+        {
+          "name": "contract_id",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "result": {
+        "name": "Workloads",
+        "schema": {
+          "$ref": "#/components/schemas/Workloads"
+        }
+      }
+    },
+    {
+      "name": "deployment.delete",
+      "params": [
+        {
+          "name": "contract_id",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "result": {
+        "name": "deleteResult",
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "name": "gpu.list",
+      "params": [],
+      "result": {
+        "name": "Gpus",
+        "schema": {
+          "$ref": "#/components/schemas/GPUs"
+        }
+      }
+    },
+    {
+      "name": "storage.pools",
+      "params": [],
+      "result": {
+        "name": "PoolMetrics",
+        "schema": {
+          "$ref": "#/components/schemas/PoolMetricsResult"
+        }
+      }
+    },
+    {
+      "name": "statistics",
+      "params": [],
+      "result": {
+        "name": "Counters",
+        "schema": {
+          "$ref": "#/components/schemas/Counters"
+        }
+      }
+    },
+    {
+      "name": "vm.logs",
+      "params": [
+        {
+          "name": "file_name",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "LogContent",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "location.get",
+      "params": [],
+      "result": {
+        "name": "Location",
+        "schema": {
+          "$ref": "#/components/schemas/Location"
+        }
+      }
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Version": {
+        "type": "object",
+        "properties": {
+          "zos": {
+            "type": "string"
+          },
+          "zinit": {
+            "type": "string"
+          }
+        }
+      },
+      "DMI": {
+        "type": "object",
+        "properties": {
+          "tooling": {
+            "$ref": "#/components/schemas/Tooling"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Section"
+            }
+          }
+        }
+      },
+      "Tooling": {
+        "type": "object",
+        "properties": {
+          "aggregator": {
+            "type": "string"
+          },
+          "decoder": {
+            "type": "string"
+          }
+        }
+      },
+      "Section": {
+        "type": "object",
+        "properties": {
+          "handleline": {
+            "type": "string"
+          },
+          "typestr": {
+            "type": "string"
+          },
+          "typenum": {
+            "type": "integer"
+          },
+          "subsections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubSection"
+            }
+          }
+        }
+      },
+      "SubSection": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PropertyData"
+            }
+          }
+        }
+      },
+      "PropertyData": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Diagnostics": {
+        "type": "object",
+        "properties": {
+          "cpu": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CPUInfo"
+            }
+          },
+          "memory": {
+            "$ref": "#/components/schemas/MemoryInfo"
+          },
+          "disks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiskInfo"
+            }
+          },
+          "processes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcessesInfo"
+            }
+          }
+        }
+      },
+      "CPUInfo": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "number"
+          },
+          "system": {
+            "type": "number"
+          },
+          "idle": {
+            "type": "number"
+          }
+        }
+      },
+      "MemoryInfo": {
+        "type": "object",
+        "properties": {
+          "used": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
+          "cached": {
+            "type": "integer"
+          },
+          "buffers": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "usedswap": {
+            "type": "integer"
+          },
+          "totalswap": {
+            "type": "integer"
+          }
+        }
+      },
+      "DiskInfo": {
+        "type": "object",
+        "properties": {
+          "device": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "used": {
+            "type": "integer"
+          },
+          "filesystem": {
+            "type": "string"
+          },
+          "mounted": {
+            "type": "string"
+          }
+        }
+      },
+      "ProcessesInfo": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "cpu": {
+            "type": "number"
+          },
+          "memory": {
+            "type": "number"
+          },
+          "rss": {
+            "type": "integer"
+          },
+          "vms": {
+            "type": "integer"
+          },
+          "swap": {
+            "type": "integer"
+          },
+          "time": {
+            "type": "integer"
+          }
+        }
+      },
+      "GPUs": {
+        "type": "object",
+        "properties": {
+          "gpus": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GPU"
+            }
+          }
+        }
+      },
+      "GPU": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "device": {
+            "type": "string"
+          },
+          "contract": {
+            "type": "integer"
+          }
+        }
+      },
+      "PoolMetricsResult": {
+        "type": "object",
+        "properties": {
+          "pools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PoolMetrics"
+            }
+          }
+        }
+      },
+      "PoolMetrics": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "used": {
+            "type": "integer"
+          },
+          "available": {
+            "type": "integer"
+          }
+        }
+      },
+      "Counters": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/UsersCounters"
+            }
+          }
+        }
+      },
+      "UsersCounters": {
+        "type": "object",
+        "properties": {
+          "deployments": {
+            "type": "integer"
+          },
+          "workloads": {
+            "type": "integer"
+          },
+          "last_deployment_timestamp": {
+            "type": "integer"
+          }
+        }
+      },
+      "CpuBenchTaskResult": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer"
+          },
+          "result": {
+            "$ref": "#/components/schemas/CPUBenchmarkResult"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CPUBenchmarkResult": {
+        "type": "object",
+        "properties": {
+          "single": {
+            "type": "number"
+          },
+          "multi": {
+            "type": "number"
+          },
+          "threads": {
+            "type": "integer"
+          },
+          "workloads": {
+            "type": "integer"
+          }
+        }
+      },
+      "HealthTaskResult": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HealthReport"
+            }
+          }
+        }
+      },
+      "HealthReport": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "test_name": {
+            "type": "string"
+          }
+        }
+      },
+      "IperfTaskResult": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IperfResult"
+            }
+          }
+        }
+      },
+      "IperfResult": {
+        "type": "object",
+        "properties": {
+          "node_id": {
+            "type": "integer"
+          },
+          "node_ip": {
+            "type": "string"
+          },
+          "test_type": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "cpu_report": {
+            "$ref": "#/components/schemas/CPUUtilizationPercent"
+          },
+          "upload_speed": {
+            "type": "number"
+          },
+          "download_speed": {
+            "type": "number"
+          }
+        }
+      },
+      "CPUUtilizationPercent": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "number"
+          },
+          "system": {
+            "type": "number"
+          },
+          "idle": {
+            "type": "number"
+          }
+        }
+      },
+      "PublicIpTaskResult": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IPReport"
+            }
+          }
+        }
+      },
+      "IPReport": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "AllTaskResult": {
+        "type": "object",
+        "properties": {
+          "health_check": {
+            "$ref": "#/components/schemas/HealthTaskResult"
+          },
+          "iperf": {
+            "$ref": "#/components/schemas/IperfTaskResult"
+          },
+          "public_ip": {
+            "$ref": "#/components/schemas/PublicIpTaskResult"
+          },
+          "cpu_benchmark": {
+            "$ref": "#/components/schemas/CpuBenchTaskResult"
+          }
+        }
+      },
+      "Interfaces": {
+        "type": "object",
+        "properties": {
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Interface"
+            }
+          }
+        }
+      },
+      "Interface": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "ips": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mac": {
+            "type": "string"
+          }
+        }
+      },
+      "Ips": {
+        "type": "object",
+        "properties": {
+          "ips": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WGPorts": {
+        "type": "object",
+        "properties": {
+          "ports": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "PublicConfig": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ipv4": {
+            "type": "string"
+          },
+          "ipv6": {
+            "type": "string"
+          },
+          "gw4": {
+            "type": "string"
+          },
+          "gw6": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          }
+        }
+      },
+      "ExitDevice": {
+        "type": "object",
+        "properties": {
+          "is_single": {
+            "type": "boolean",
+            "description": "Set to true if br-pub is connected to zos bridge"
+          },
+          "is_dual": {
+            "type": "boolean",
+            "description": "Set to true if br-pub is connected to a physical nic"
+          },
+          "dual_interface": {
+            "type": "string",
+            "description": "Set to the physical interface name if is_dual is true"
+          }
+        }
+      },
+      "Deployments": {
+        "type": "object",
+        "properties": {
+          "deployments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Deployment"
+            }
+          }
+        }
+      },
+      "Workloads": {
+        "type": "object",
+        "properties": {
+          "workloads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Workload"
+            }
+          }
+        }
+      },
+      "Workload": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          },
+          "metadata": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "result": {
+            "$ref": "#/components/schemas/WorkloadResult"
+          }
+        }
+      },
+      "WorkloadResult": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "type": "integer"
+          },
+          "state": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      },
+      "Deployment": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer"
+          },
+          "twin_id": {
+            "type": "integer"
+          },
+          "contract_id": {
+            "type": "integer"
+          },
+          "metadata": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "expiration": {
+            "type": "integer"
+          },
+          "workloads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Workload"
+            }
+          },
+          "signature_requirement": {
+            "$ref": "#/components/schemas/SignatureRequirement"
+          }
+        }
+      },
+      "SignatureRequirement": {
+        "type": "object",
+        "properties": {
+          "requests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SignatureRequest"
+            }
+          },
+          "weight_required": {
+            "type": "integer"
+          },
+          "signatures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Signature"
+            }
+          },
+          "signature_style": {
+            "type": "string"
+          }
+        }
+      },
+      "SignatureRequest": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "integer"
+          },
+          "twin_id": {
+            "type": "integer"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Signature": {
+        "type": "object",
+        "properties": {
+          "twin_id": {
+            "type": "integer"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "signature_type": {
+            "type": "string"
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "country": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "longitude": {
+            "type": "number"
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "continent": {
+            "type": "string"
+          },
+          "region_name": {
+            "type": "string"
+          },
+          "region_code": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"errors"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zosbase/pkg/capacity"
+	"github.com/threefoldtech/zosbase/pkg/diagnostics"
+	"github.com/threefoldtech/zosbase/pkg/stubs"
+)
+
+const (
+	cacheDefaultExpiration = 24 * time.Hour
+	cacheDefaultCleanup    = 24 * time.Hour
+	lightMode              = "light"
+)
+
+var (
+	ErrNotSupportedInLightMode = errors.New("method is not supported in light mode")
+)
+
+type API struct {
+	mode                   string
+	oracle                 *capacity.ResourceOracle
+	versionMonitorStub     *stubs.VersionMonitorStub
+	systemMonitorStub      *stubs.SystemMonitorStub
+	provisionStub          *stubs.ProvisionStub
+	networkerStub          *stubs.NetworkerStub
+	networkerLightStub     *stubs.NetworkerLightStub
+	statisticsStub         *stubs.StatisticsStub
+	storageStub            *stubs.StorageModuleStub
+	performanceMonitorStub *stubs.PerformanceMonitorStub
+	diagnosticsManager     *diagnostics.DiagnosticsManager
+	inMemCache             *cache.Cache
+}
+
+func NewAPI(client zbus.Client, msgBrokerCon string, mode string) (*API, error) {
+	diagnosticsManager, err := diagnostics.NewDiagnosticsManager(msgBrokerCon, client)
+	if err != nil {
+		return nil, err
+	}
+
+	storageModuleStub := stubs.NewStorageModuleStub(client)
+
+	api := &API{
+		mode:                   mode,
+		storageStub:            storageModuleStub,
+		diagnosticsManager:     diagnosticsManager,
+		oracle:                 capacity.NewResourceOracle(storageModuleStub),
+		versionMonitorStub:     stubs.NewVersionMonitorStub(client),
+		systemMonitorStub:      stubs.NewSystemMonitorStub(client),
+		provisionStub:          stubs.NewProvisionStub(client),
+		statisticsStub:         stubs.NewStatisticsStub(client),
+		performanceMonitorStub: stubs.NewPerformanceMonitorStub(client),
+	}
+
+	if mode == lightMode {
+		api.networkerLightStub = stubs.NewNetworkerLightStub(client)
+	} else {
+		api.networkerStub = stubs.NewNetworkerStub(client)
+	}
+
+	api.inMemCache = cache.New(cacheDefaultExpiration, cacheDefaultCleanup)
+	return api, nil
+}
+
+func (a *API) isLightMode() bool {
+	return a.mode == lightMode
+}

--- a/pkg/api/deployment.go
+++ b/pkg/api/deployment.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+)
+
+func (a *API) DeploymentDeployHandler(ctx context.Context, deployment gridtypes.Deployment) error {
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.CreateOrUpdate(ctx, twinID, deployment, false)
+}
+
+func (a *API) DeploymentUpdateHandler(ctx context.Context, deployment gridtypes.Deployment) error {
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.CreateOrUpdate(ctx, twinID, deployment, true)
+}
+
+func (a *API) DeploymentDeleteHandler(ctx context.Context, contractID uint64) error {
+	return errors.New("deletion over the api is disabled, please cancel your contract instead")
+}
+
+func (a *API) DeploymentGetHandler(ctx context.Context, contractID uint64) (gridtypes.Deployment, error) {
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return gridtypes.Deployment{}, errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.Get(ctx, twinID, contractID)
+}
+
+func (a *API) DeploymentListHandler(ctx context.Context) ([]gridtypes.Deployment, error) {
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return nil, errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.List(ctx, twinID)
+}
+
+func (a *API) DeploymentChangesHandler(ctx context.Context, contractID uint64) ([]gridtypes.Workload, error) {
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return nil, errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.Changes(ctx, twinID, contractID)
+}

--- a/pkg/api/location.go
+++ b/pkg/api/location.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/threefoldtech/zosbase/pkg/geoip"
+)
+
+const (
+	locationCacheKey = "location"
+)
+
+func (a *API) LocationGet(ctx context.Context) (geoip.Location, error) {
+	if loc, found := a.inMemCache.Get(locationCacheKey); found {
+		if loc, ok := loc.(geoip.Location); ok {
+			return loc, nil
+		}
+
+		return geoip.Location{}, fmt.Errorf("failed to convert cached location")
+	}
+
+	loc, err := geoip.Fetch()
+	if err != nil {
+		return geoip.Location{}, err
+	}
+	a.inMemCache.Set(locationCacheKey, loc, cache.DefaultExpiration)
+
+	return loc, nil
+}

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// GetVmLogsHandler returns VM logs
+func (a *API) GetVmLogsHandler(ctx context.Context, fileName string) (string, error) {
+	rootPath := "/var/cache/modules/vmd/logs/"
+	fullPath := filepath.Join(rootPath, fileName)
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file, path: %s, %w", fullPath, err)
+	}
+
+	return string(content), nil
+}

--- a/pkg/api/monitor.go
+++ b/pkg/api/monitor.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"context"
+
+	"github.com/threefoldtech/zosbase/pkg"
+)
+
+func (a *API) PerfSpeed(ctx context.Context) (pkg.IperfTaskResult, error) {
+	return a.performanceMonitorStub.GetIperfTaskResult(ctx)
+}
+
+func (a *API) PerfHealth(ctx context.Context) (pkg.HealthTaskResult, error) {
+	return a.performanceMonitorStub.GetHealthTaskResult(ctx)
+}
+
+func (a *API) PerfPublicIp(ctx context.Context) (pkg.PublicIpTaskResult, error) {
+	return a.performanceMonitorStub.GetPublicIpTaskResult(ctx)
+}
+
+func (a *API) PerfBenchmark(ctx context.Context) (pkg.CpuBenchTaskResult, error) {
+	return a.performanceMonitorStub.GetCpuBenchTaskResult(ctx)
+}
+
+func (a *API) PerfAll(ctx context.Context) (pkg.AllTaskResult, error) {
+	return a.performanceMonitorStub.GetAllTaskResult(ctx)
+}

--- a/pkg/api/network.go
+++ b/pkg/api/network.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/threefoldtech/zosbase/pkg"
+	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+)
+
+func (a *API) NetworkWGPorts(ctx context.Context) ([]uint, error) {
+	if a.isLightMode() {
+		return nil, ErrNotSupportedInLightMode
+	}
+	return a.networkerStub.WireguardPorts(ctx)
+}
+
+func (a *API) NetworkPublicConfigGet(ctx context.Context, _ any) (pkg.PublicConfig, error) {
+	if a.isLightMode() {
+		return pkg.PublicConfig{}, ErrNotSupportedInLightMode
+	}
+
+	return a.networkerStub.GetPublicConfig(ctx)
+}
+
+func (a *API) NetworkHasIPv6(ctx context.Context) (bool, error) {
+	if a.isLightMode() {
+		return false, nil
+	}
+
+	ipData, err := a.networkerStub.GetPublicIPv6Subnet(ctx)
+	hasIP := ipData.IP != nil && err == nil
+	return hasIP, nil
+
+}
+
+func (a *API) NetworkListPublicIPs(ctx context.Context) ([]string, error) {
+	if a.isLightMode() {
+		return nil, ErrNotSupportedInLightMode
+	}
+
+	return a.provisionStub.ListPublicIPs(ctx)
+}
+
+func (a *API) NetworkListPrivateIPs(ctx context.Context, networkName string) ([]string, error) {
+	name := gridtypes.Name(networkName)
+	twinID, ok := ctx.Value("twin_id").(uint32)
+	if !ok {
+		return nil, errors.New("could not get twin_id from context")
+	}
+	return a.provisionStub.ListPrivateIPs(ctx, twinID, name)
+}
+
+func (a *API) NetworkInterfaces(ctx context.Context) (pkg.Interfaces, error) {
+	if a.isLightMode() {
+		return a.networkerLightStub.Interfaces(ctx, "zos", "")
+	}
+
+	type q struct {
+		inf    string
+		ns     string
+		rename string
+	}
+	result := pkg.Interfaces{
+		Interfaces: make(map[string]pkg.Interface),
+	}
+	for _, i := range []q{{"zos", "", "zos"}, {"nygg6", "ndmz", "ygg"}} {
+		ips, mac, err := a.networkerStub.Addrs(ctx, i.inf, i.ns)
+		if err != nil {
+			return pkg.Interfaces{Interfaces: make(map[string]pkg.Interface)}, fmt.Errorf("failed to get ips for '%s' interface: %w", i.inf, err)
+		}
+
+		iface := pkg.Interface{
+			Name: i.rename,
+			Mac:  mac,
+			IPs:  []net.IPNet{},
+		}
+
+		for _, item := range ips {
+			ipNet := net.IPNet{
+				IP:   item,
+				Mask: nil,
+			}
+			iface.IPs = append(iface.IPs, ipNet)
+		}
+
+		result.Interfaces[i.rename] = iface
+	}
+
+	return result, nil
+}
+
+// all interfaces on the node
+func (a *API) AdminInterfaces(ctx context.Context) (pkg.Interfaces, error) {
+	if a.isLightMode() {
+		return a.networkerLightStub.Interfaces(ctx, "", "")
+	}
+
+	return a.networkerStub.Interfaces(ctx, "", "")
+}
+
+func (a *API) AdminSetPublicNIC(ctx context.Context, device string) error {
+	if a.isLightMode() {
+		return ErrNotSupportedInLightMode
+	}
+	return a.networkerStub.SetPublicExitDevice(ctx, device)
+}
+
+func (a *API) AdminGetPublicNIC(ctx context.Context) (pkg.ExitDevice, error) {
+	if a.isLightMode() {
+		return pkg.ExitDevice{}, ErrNotSupportedInLightMode
+	}
+
+	return a.networkerStub.GetPublicExitDevice(ctx)
+}

--- a/pkg/api/statistics.go
+++ b/pkg/api/statistics.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"context"
+
+	"github.com/threefoldtech/zosbase/pkg"
+)
+
+func (a *API) Statistics(ctx context.Context) (pkg.Counters, error) {
+	return a.statisticsStub.GetCounters(ctx)
+}
+
+func (a *API) GpuList(ctx context.Context) ([]pkg.GPUInfo, error) {
+	return a.statisticsStub.ListGPUs(ctx)
+}

--- a/pkg/api/storage.go
+++ b/pkg/api/storage.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"context"
+
+	"github.com/threefoldtech/zosbase/pkg"
+)
+
+func (a *API) StoragePoolsHandler(ctx context.Context) ([]pkg.PoolMetrics, error) {
+	return a.storageStub.Metrics(ctx)
+}

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/threefoldtech/zosbase/pkg"
+	"github.com/threefoldtech/zosbase/pkg/capacity/dmi"
+	"github.com/threefoldtech/zosbase/pkg/diagnostics"
+)
+
+func (a *API) SystemVersion(ctx context.Context) (Version, error) {
+	output, err := exec.CommandContext(ctx, "zinit", "-V").CombinedOutput()
+	var zInitVer string
+	if err != nil {
+		zInitVer = err.Error()
+	} else {
+		zInitVer = strings.TrimSpace(strings.TrimPrefix(string(output), "zinit"))
+	}
+
+	version := Version{
+		Zos:   a.versionMonitorStub.GetVersion(ctx).String(),
+		Zinit: zInitVer,
+	}
+
+	return version, nil
+}
+
+func (a *API) SystemDMI(ctx context.Context) (dmi.DMI, error) {
+	dmi, err := a.oracle.DMI()
+	return *dmi, err
+}
+
+func (a *API) SystemHypervisor(ctx context.Context) (string, error) {
+	return a.oracle.GetHypervisor()
+}
+
+func (a *API) SystemDiagnostics(ctx context.Context) (diagnostics.Diagnostics, error) {
+	return a.diagnosticsManager.GetSystemDiagnostics(ctx)
+}
+
+func (a *API) SystemNodeFeatures(ctx context.Context) []pkg.NodeFeature {
+	return a.systemMonitorStub.GetNodeFeatures(ctx)
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,7 @@
+package api
+
+// Version represents the version of the node
+type Version struct {
+	Zos   string `json:"zos"`
+	Zinit string `json:"zinit"`
+}

--- a/pkg/perf/cache_utils.go
+++ b/pkg/perf/cache_utils.go
@@ -1,0 +1,72 @@
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/zosbase/pkg"
+)
+
+const (
+	moduleName           = "perf"
+	healthCheckTaskName  = "healthcheck"
+	iperfTaskName        = "iperf"
+	publicIpTaskName     = "public-ip-validation"
+	cpuBenchmarkTaskName = "cpu-benchmark"
+)
+
+var (
+	ErrResultNotFound = errors.New("result not found")
+)
+
+func generatePerfKey(taskName string) string {
+	return fmt.Sprintf("%s.%s", moduleName, taskName)
+}
+
+func (pm *PerformanceMonitor) exists(key string) (bool, error) {
+	conn := pm.pool.Get()
+	defer conn.Close()
+	key = generatePerfKey(key)
+
+	ok, err := redis.Bool(conn.Do("EXISTS", key))
+	if err != nil {
+		return false, errors.Wrapf(err, "error checking if key %s exists", key)
+	}
+	return ok, nil
+}
+
+func (pm *PerformanceMonitor) get(key string) ([]byte, error) {
+	conn := pm.pool.Get()
+	defer conn.Close()
+	key = generatePerfKey(key)
+
+	data, err := redis.Bytes(conn.Do("GET", key))
+	if err != nil {
+		if err == redis.ErrNil {
+			return nil, ErrResultNotFound
+		}
+		return nil, errors.Wrap(err, "failed to get the result")
+	}
+
+	if data == nil {
+		return nil, ErrResultNotFound
+	}
+
+	return data, nil
+}
+
+func (pm *PerformanceMonitor) set(result pkg.TaskResult) error {
+	conn := pm.pool.Get()
+	defer conn.Close()
+	key := generatePerfKey(result.Name)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal data to JSON")
+	}
+
+	_, err = conn.Do("SET", key, data)
+	return err
+}

--- a/pkg/perf/monitor.go
+++ b/pkg/perf/monitor.go
@@ -63,7 +63,7 @@ func (pm *PerformanceMonitor) runTask(ctx context.Context, task Task) error {
 		return errors.Wrapf(err, "failed to run task: %s", task.ID())
 	}
 
-	err = pm.setCache(ctx, pkg.TaskResult{
+	err = pm.set(pkg.TaskResult{
 		Name:        task.ID(),
 		Timestamp:   uint64(time.Now().Unix()),
 		Description: task.Description(),

--- a/pkg/performance_monitor.go
+++ b/pkg/performance_monitor.go
@@ -3,6 +3,12 @@ package pkg
 //go:generate zbusc -module node -version 0.0.1 -name performance-monitor -package stubs github.com/threefoldtech/zosbase/pkg+PerformanceMonitor stubs/performance_monitor_stub.go
 
 type PerformanceMonitor interface {
+	GetAllTaskResult() (AllTaskResult, error)
+	GetIperfTaskResult() (IperfTaskResult, error)
+	GetHealthTaskResult() (HealthTaskResult, error)
+	GetPublicIpTaskResult() (PublicIpTaskResult, error)
+	GetCpuBenchTaskResult() (CpuBenchTaskResult, error)
+	// Deprecated
 	Get(taskName string) (TaskResult, error)
 	GetAll() ([]TaskResult, error)
 }
@@ -13,4 +19,87 @@ type TaskResult struct {
 	Description string      `json:"description"`
 	Timestamp   uint64      `json:"timestamp"`
 	Result      interface{} `json:"result"`
+}
+
+// CPUUtilizationPercent represents CPU utilization percentages
+type CPUUtilizationPercent struct {
+	Host                float64 `json:"host_total"`
+	HostUser            float64 `json:"host_user"`
+	HostSystem          float64 `json:"host_system"`
+	RemoteTotal         float64 `json:"remote_total"`
+	RemoteUser          float64 `json:"remote_user"`
+	RemoteSystem        float64 `json:"remote_system"`
+	RemoteTotalMessage  float64 `json:"remote_total_message"`
+	RemoteUserMessage   float64 `json:"remote_user_message"`
+	RemoteSystemMessage float64 `json:"remote_system_message"`
+}
+
+// IperfResult for iperf test results
+type IperfResult struct {
+	UploadSpeed   float64               `json:"upload_speed"`   // in bit/sec
+	DownloadSpeed float64               `json:"download_speed"` // in bit/sec
+	NodeID        uint32                `json:"node_id"`
+	NodeIpv4      string                `json:"node_ip"`
+	TestType      string                `json:"test_type"`
+	Error         string                `json:"error"`
+	CpuReport     CPUUtilizationPercent `json:"cpu_report"`
+}
+
+type TaskResultBase struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Timestamp   uint64 `json:"timestamp"`
+}
+
+// IperfTaskResult represents the result of an iperf task
+type IperfTaskResult struct {
+	TaskResultBase
+	Result []IperfResult `json:"result"`
+}
+
+// HealthReport represents a health check report
+type HealthReport struct {
+	TestName string   `json:"test_name"`
+	Errors   []string `json:"errors"`
+}
+
+// HealthTaskResult represents the result of a health check task
+type HealthTaskResult struct {
+	TaskResultBase
+	Result HealthReport `json:"result"`
+}
+
+// Report represents a public IP validation report
+type Report struct {
+	Ip     string `json:"ip"`
+	State  string `json:"state"`
+	Reason string `json:"reason"`
+}
+
+// PublicIpTaskResult represents the result of a public IP validation task
+type PublicIpTaskResult struct {
+	TaskResultBase
+	Result []Report `json:"result"`
+}
+
+// CPUBenchmarkResult holds CPU benchmark results
+type CPUBenchmarkResult struct {
+	SingleThreaded float64 `json:"single"`
+	MultiThreaded  float64 `json:"multi"`
+	Threads        int     `json:"threads"`
+	Workloads      int     `json:"workloads"`
+}
+
+// CpuBenchTaskResult represents the result of a CPU benchmark task
+type CpuBenchTaskResult struct {
+	TaskResultBase
+	Result CPUBenchmarkResult `json:"result"`
+}
+
+// AllTaskResult represents all task results combined
+type AllTaskResult struct {
+	CpuBenchmark CpuBenchTaskResult `json:"cpu_benchmark"`
+	HealthCheck  HealthTaskResult   `json:"health_check"`
+	Iperf        IperfTaskResult    `json:"iperf"`
+	PublicIp     PublicIpTaskResult `json:"public_ip"`
 }

--- a/pkg/receiver/handlers.go
+++ b/pkg/receiver/handlers.go
@@ -1,0 +1,247 @@
+package receiver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+)
+
+func (r *Receiver) registerHandler(method string, handler HandlerFunc) {
+	r.handlers[method] = handler
+}
+
+func (r *Receiver) registerHandlers() {
+	handlers := map[string]HandlerFunc{
+		"system.version":     r.handleSystemVersion,
+		"system.dmi":         r.handleSystemDMI,
+		"system.hypervisor":  r.handleSystemHypervisor,
+		"system.diagnostics": r.handleSystemDiagnostics,
+		"system.features":    r.handleSystemNodeFeatures,
+
+		"monitor.speed":     r.handlePerfSpeed,
+		"monitor.health":    r.handlePerfHealth,
+		"monitor.publicip":  r.handlePerfPublicIp,
+		"monitor.benchmark": r.handlePerfBenchmark,
+		"monitor.all":       r.handlePerfAll,
+
+		"network.wg_ports":       r.handleNetworkWGPorts,
+		"network.public_config":  r.handleNetworkPublicConfig,
+		"network.has_ipv6":       r.handleNetworkHasIPv6,
+		"network.public_ips":     r.handleNetworkPublicIPs,
+		"network.private_ips":    r.handleNetworkPrivateIPs,
+		"network.interfaces":     r.handleNetworkInterfaces,
+		"network.set_public_nic": r.handleAdminSetPublicNIC,
+		"network.get_public_nic": r.handleAdminGetPublicNIC,
+		// "network.admin.interfaces":     r.handleAdminInterfaces,
+
+		"deployment.deploy":  r.handleDeploymentDeploy,
+		"deployment.update":  r.handleDeploymentUpdate,
+		"deployment.get":     r.handleDeploymentGet,
+		"deployment.list":    r.handleDeploymentList,
+		"deployment.changes": r.handleDeploymentChanges,
+		// "deployment.delete":  r.handleDeploymentDelete,
+
+		"gpu.list":      r.handleGpuList,
+		"storage.pools": r.handleStoragePools,
+		"statistics":    r.handleStatistics,
+		"location.get":  r.handleLocationGet,
+		// "vm.logs":       r.handleVmLogs,
+	}
+
+	for method, handler := range handlers {
+		r.registerHandler(method, handler)
+	}
+}
+
+func extractObject(params json.RawMessage, obj interface{}) error {
+	if err := json.Unmarshal(params, obj); err != nil {
+		return fmt.Errorf("invalid object parameter: %w", err)
+	}
+	return nil
+}
+
+func (r *Receiver) handleSystemVersion(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.SystemVersion(ctx)
+}
+
+func (r *Receiver) handleSystemDMI(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.SystemDMI(ctx)
+}
+
+func (r *Receiver) handleSystemHypervisor(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.SystemHypervisor(ctx)
+}
+
+func (r *Receiver) handleSystemDiagnostics(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.SystemDiagnostics(ctx)
+}
+
+func (r *Receiver) handleSystemNodeFeatures(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.SystemNodeFeatures(ctx), nil
+}
+
+func (r *Receiver) handlePerfSpeed(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.PerfSpeed(ctx)
+}
+
+func (r *Receiver) handlePerfHealth(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.PerfHealth(ctx)
+}
+
+func (r *Receiver) handlePerfPublicIp(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.PerfPublicIp(ctx)
+}
+
+func (r *Receiver) handlePerfBenchmark(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.PerfBenchmark(ctx)
+}
+
+func (r *Receiver) handlePerfAll(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.PerfAll(ctx)
+}
+
+func (r *Receiver) handleGpuList(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.GpuList(ctx)
+}
+
+func (r *Receiver) handleStoragePools(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.StoragePoolsHandler(ctx)
+}
+
+func (r *Receiver) handleNetworkWGPorts(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.NetworkWGPorts(ctx)
+}
+
+func (r *Receiver) handleNetworkPublicConfig(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.NetworkPublicConfigGet(ctx, nil)
+}
+
+func (r *Receiver) handleNetworkHasIPv6(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.NetworkHasIPv6(ctx)
+}
+
+func (r *Receiver) handleNetworkPublicIPs(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.NetworkListPublicIPs(ctx)
+}
+
+func (r *Receiver) handleNetworkPrivateIPs(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type networkParams struct {
+		NetworkName string `json:"network_name"`
+	}
+
+	var p networkParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return r.api.NetworkListPrivateIPs(ctx, p.NetworkName)
+}
+
+func (r *Receiver) handleNetworkInterfaces(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.NetworkInterfaces(ctx)
+}
+
+func (r *Receiver) handleAdminInterfaces(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.AdminInterfaces(ctx)
+}
+
+func (r *Receiver) handleAdminSetPublicNIC(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type deviceParams struct {
+		Device string `json:"device"`
+	}
+
+	var p deviceParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return nil, r.api.AdminSetPublicNIC(ctx, p.Device)
+}
+
+func (r *Receiver) handleAdminGetPublicNIC(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.AdminGetPublicNIC(ctx)
+}
+
+func (r *Receiver) handleDeploymentDeploy(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	var deployment gridtypes.Deployment
+	if err := extractObject(params, &deployment); err != nil {
+		return nil, err
+	}
+
+	return nil, r.api.DeploymentDeployHandler(ctx, deployment)
+}
+
+func (r *Receiver) handleDeploymentUpdate(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	var deployment gridtypes.Deployment
+	if err := extractObject(params, &deployment); err != nil {
+		return nil, err
+	}
+
+	return nil, r.api.DeploymentUpdateHandler(ctx, deployment)
+}
+
+func (r *Receiver) handleDeploymentGet(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type contractParams struct {
+		ContractID uint64 `json:"contract_id"`
+	}
+
+	var p contractParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return r.api.DeploymentGetHandler(ctx, p.ContractID)
+}
+
+func (r *Receiver) handleDeploymentList(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.DeploymentListHandler(ctx)
+}
+
+func (r *Receiver) handleDeploymentChanges(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type contractParams struct {
+		ContractID uint64 `json:"contract_id"`
+	}
+
+	var p contractParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return r.api.DeploymentChangesHandler(ctx, p.ContractID)
+}
+
+func (r *Receiver) handleDeploymentDelete(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type contractParams struct {
+		ContractID uint64 `json:"contract_id"`
+	}
+
+	var p contractParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return nil, r.api.DeploymentDeleteHandler(ctx, p.ContractID)
+}
+
+func (r *Receiver) handleStatistics(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.Statistics(ctx)
+}
+
+func (r *Receiver) handleVmLogs(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	type fileParams struct {
+		FileName string `json:"file_name"`
+	}
+
+	var p fileParams
+	if err := extractObject(params, &p); err != nil {
+		return nil, err
+	}
+
+	return r.api.GetVmLogsHandler(ctx, p.FileName)
+}
+
+func (r *Receiver) handleLocationGet(ctx context.Context, params json.RawMessage) (interface{}, error) {
+	return r.api.LocationGet(ctx)
+}

--- a/pkg/receiver/receiver.go
+++ b/pkg/receiver/receiver.go
@@ -1,0 +1,230 @@
+package receiver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zosbase/pkg/api"
+	"github.com/threefoldtech/zosbase/pkg/environment"
+	"github.com/threefoldtech/zosbase/pkg/network/namespace"
+)
+
+const (
+	retryInterval = 100 * time.Millisecond
+
+	// JSON-RPC error codes
+	ErrCodeParseError     = -32700
+	ErrCodeInvalidRequest = -32600
+	ErrCodeMethodNotFound = -32601
+	ErrCodeInvalidParams  = -32602
+	ErrCodeInternalError  = -32000
+)
+
+type Receiver struct {
+	api       *api.API
+	handlers  map[string]HandlerFunc
+	namespace string // network namespace where mycelium is running
+	stopCh    chan struct{}
+	wg        sync.WaitGroup
+	running   bool
+}
+
+func NewReceiver(api *api.API, namespace string) *Receiver {
+	receiver := &Receiver{
+		api:       api,
+		namespace: namespace,
+		handlers:  make(map[string]HandlerFunc),
+		stopCh:    make(chan struct{}),
+	}
+
+	receiver.registerHandlers()
+
+	return receiver
+}
+
+func (r *Receiver) Run(ctx context.Context) error {
+	log.Info().Str("namespace", r.namespace).Msg("starting receiver...")
+	r.running = true
+
+	r.wg.Add(1)
+	defer r.wg.Done()
+
+	if r.namespace == "" {
+		r.receiveLoop(ctx)
+		return nil
+	}
+
+	netns, err := namespace.GetByName(r.namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get network namespace %s: %w", r.namespace, err)
+	}
+	defer netns.Close()
+
+	return netns.Do(func(_ ns.NetNS) error {
+		r.receiveLoop(ctx)
+		return nil
+	})
+}
+
+func (r *Receiver) Stop() {
+	log.Info().Msg("stopping receiver...")
+	r.wg.Wait()
+
+	close(r.stopCh)
+}
+
+func (r *Receiver) receiveLoop(ctx context.Context) {
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		default:
+			if err := r.receiveAndProcessMessage(ctx); err != nil {
+				log.Error().Err(err).Msg("error processing message")
+				time.Sleep(retryInterval)
+			}
+		}
+	}
+}
+
+func (r *Receiver) receiveAndProcessMessage(ctx context.Context) error {
+	log.Debug().Msg("ready to receive messages...")
+	cmd := exec.CommandContext(ctx, "mycelium", "message", "receive")
+	raw, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to receive message: %w", err)
+	}
+
+	var message Message
+	if err := json.Unmarshal(raw, &message); err != nil {
+		return fmt.Errorf("failed to parse message: %w", err)
+	}
+	log.Debug().
+		Str("src_ip", message.SrcIP).
+		Str("message_id", message.ID).
+		Msg("received message")
+
+	response := r.processRequest(ctx, message)
+	return r.sendResponse(message.SrcPK, message.ID, response)
+}
+
+func (r *Receiver) processRequest(ctx context.Context, message Message) JSONRPCResponse {
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      message.ID,
+	}
+
+	var request JSONRPCRequest
+	if err := json.Unmarshal([]byte(message.Payload), &request); err != nil {
+		response.Error = &RPCError{
+			Code:    ErrCodeParseError,
+			Message: "Parse error",
+			Data:    err.Error(),
+		}
+		return response
+	}
+
+	log.Debug().
+		Str("method", request.Method).
+		Msg("executing handler")
+
+	if request.JSONRPC != "2.0" {
+		response.Error = &RPCError{
+			Code:    ErrCodeInvalidRequest,
+			Message: "Invalid Request",
+			Data:    "jsonrpc version must be 2.0",
+		}
+		return response
+	}
+
+	response.ID = request.ID
+
+	handler, ok := r.handlers[request.Method]
+	if !ok {
+		response.Error = &RPCError{
+			Code:    ErrCodeMethodNotFound,
+			Message: "Method not found",
+			Data:    request.Method,
+		}
+		return response
+	}
+
+	params := json.RawMessage("{}")
+	if request.Params != nil {
+		var err error
+		if params, err = json.Marshal(request.Params); err != nil {
+			response.Error = &RPCError{
+				Code:    ErrCodeInvalidParams,
+				Message: "Invalid params",
+				Data:    err.Error(),
+			}
+			return response
+		}
+	}
+
+	twin, err := getTwinFromPublicKey(ctx, message.SrcPK)
+	if err != nil || twin == 0 {
+		response.Error = &RPCError{
+			Code:    ErrCodeInternalError,
+			Message: "Failed to get twin from chain",
+			Data:    err.Error(),
+		}
+		return response
+	}
+	ctx = context.WithValue(ctx, "twin_id", twin)
+
+	result, err := handler(ctx, params)
+	if err != nil {
+		response.Error = &RPCError{
+			Code:    ErrCodeInternalError,
+			Message: err.Error(),
+		}
+		return response
+	}
+
+	response.Result = result
+	return response
+}
+
+func (r *Receiver) sendResponse(recipient string, replyTo string, response JSONRPCResponse) error {
+	responseBytes, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	args := []string{"message", "send", recipient, string(responseBytes)}
+	if replyTo != "" {
+		args = append(args, "--reply-to", replyTo)
+	}
+
+	cmd := exec.Command("mycelium", args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to send response: %w, output: %s", err, string(output))
+	}
+
+	return nil
+}
+
+func getTwinFromPublicKey(ctx context.Context, publicKey string) (uint32, error) {
+	// needs mycelium identity on the chain
+	// to get the twin id from the public key
+	manager, err := environment.GetSubstrate()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get substrate manager: %w", err)
+	}
+
+	sub, err := manager.Substrate()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get substrate: %w", err)
+	}
+
+	return sub.GetTwinByPubKey([]byte(publicKey))
+}

--- a/pkg/receiver/types.go
+++ b/pkg/receiver/types.go
@@ -1,0 +1,38 @@
+package receiver
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type Message struct {
+	ID      string `json:"id"`
+	SrcIP   string `json:"srcIp"`
+	SrcPK   string `json:"srcPk"`
+	DstIP   string `json:"dstIp"`
+	DstPK   string `json:"dstPk"`
+	Topic   string `json:"topic"`
+	Payload string `json:"payload"`
+}
+
+type JSONRPCRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+	ID      string      `json:"id"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *RPCError   `json:"error,omitempty"`
+	ID      string      `json:"id"`
+}
+
+type RPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type HandlerFunc func(ctx context.Context, params json.RawMessage) (interface{}, error)

--- a/pkg/stubs/performance_monitor_stub.go
+++ b/pkg/stubs/performance_monitor_stub.go
@@ -60,3 +60,88 @@ func (s *PerformanceMonitorStub) GetAll(ctx context.Context) (ret0 []pkg.TaskRes
 	}
 	return
 }
+
+func (s *PerformanceMonitorStub) GetAllTaskResult(ctx context.Context) (ret0 pkg.AllTaskResult, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetAllTaskResult", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *PerformanceMonitorStub) GetCpuBenchTaskResult(ctx context.Context) (ret0 pkg.CpuBenchTaskResult, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetCpuBenchTaskResult", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *PerformanceMonitorStub) GetHealthTaskResult(ctx context.Context) (ret0 pkg.HealthTaskResult, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetHealthTaskResult", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *PerformanceMonitorStub) GetIperfTaskResult(ctx context.Context) (ret0 pkg.IperfTaskResult, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetIperfTaskResult", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func (s *PerformanceMonitorStub) GetPublicIpTaskResult(ctx context.Context) (ret0 pkg.PublicIpTaskResult, ret1 error) {
+	args := []interface{}{}
+	result, err := s.client.RequestContext(ctx, s.module, s.object, "GetPublicIpTaskResult", args...)
+	if err != nil {
+		panic(err)
+	}
+	result.PanicOnError()
+	ret1 = result.CallError()
+	loader := zbus.Loader{
+		&ret0,
+	}
+	if err := result.Unmarshal(&loader); err != nil {
+		panic(err)
+	}
+	return
+}


### PR DESCRIPTION
- new `api` pkg handling both modes normal/light handlers with defined param/return type, decoupled from the messaging part
- new `reciever` pkg handling the messaging over mycelium binary with handlers mapped to api pkg
- update monitor pkg/stub for better defined-typed results
- generated openrpc file with all methods/types for api
- backward compatible: old rmb api still valid

in-progress:
- [ ] identity management, (only mycelium pk, map myc pk to twin on chain)
- [ ] new node-client over mycelium