### PR TITLE
fix flistd cleanup

### DIFF
--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -140,7 +140,7 @@ func (f *flistModule) cleanUnusedMounts() error {
 
 		if err := os.Remove(path); err != nil {
 			log.Debug().Msgf("failed to remove path, trying to forcibly clean up : %+v", path)
-			if err := f.forceUnmountAndRemove(path); err != nil {
+			if err := f.forceRemoveBrokenMounts(path); err != nil {
 				log.Error().Err(err).Msgf("failed to clean mountpoint %s", path)
 			}
 		}
@@ -149,8 +149,8 @@ func (f *flistModule) cleanUnusedMounts() error {
 	return nil
 }
 
-// forceUnmountAndRemove tries to fix the clean up of broken mounts by attempting to unmount them first
-func (f *flistModule) forceUnmountAndRemove(path string) error {
+// forceRemoveBrokenMounts tries to force the clean up of broken mounts by attempting to unmount them first
+func (f *flistModule) forceRemoveBrokenMounts(path string) error {
 	// try normal unmount first
 	err := f.system.Unmount(path, 0)
 	if err != nil {

--- a/pkg/flist/cleanup.go
+++ b/pkg/flist/cleanup.go
@@ -149,19 +149,20 @@ func (f *flistModule) cleanUnusedMounts() error {
 	return nil
 }
 
+// forceUnmountAndRemove tries to fix the clean up of broken mounts by attempting to unmount them first
 func (f *flistModule) forceUnmountAndRemove(path string) error {
-	// Try normal unmount first
+	// try normal unmount first
 	err := f.system.Unmount(path, 0)
 	if err != nil {
 		log.Warn().Err(err).Msgf("normal unmount failed for %s, trying lazy unmount", path)
 
-		// Try lazy unmount (MNT_DETACH)
-		err = syscall.Unmount(path, syscall.MNT_DETACH)
+		// try lazy unmount
+		err = f.system.Unmount(path, syscall.MNT_DETACH)
 		if err != nil {
 			return errors.Wrapf(err, "lazy unmount also failed for %s", path)
 		}
 	}
-	// Now try to remove the directory
+	// try to remove the path after unmount
 	if err := os.RemoveAll(path); err != nil {
 		return errors.Wrapf(err, "failed to remove mountpoint %s", path)
 	}


### PR DESCRIPTION
### Description

force unmount and remove in flist clean up if the path is not mountpoint but the module can not delete it

### Related Issues

https://github.com/threefoldtech/zos/issues/2581

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
