### PR TITLE
Add tests for perf/cpubench

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -75,7 +75,7 @@ type Processor struct {
 
 func NewProcessor(sub substrate.Manager, cb Callback, state State) *Processor {
 	return &Processor{
-		update: make(chan substrate.Manager, 0),
+		update: make(chan substrate.Manager),
 		sub:    sub,
 		cb:     cb,
 		state:  state,

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 
 	"github.com/threefoldtech/zosbase/pkg/perf"
-	"github.com/threefoldtech/zosbase/pkg/perf/iperf" // Import for ExecWrapper
+	execwrapper "github.com/threefoldtech/zosbase/pkg/perf/exec_wrapper"
 	"github.com/threefoldtech/zosbase/pkg/stubs"
 )
 
 // CPUBenchmarkTask defines CPU benchmark task.
 type CPUBenchmarkTask struct {
-	execWrapper iperf.ExecWrapper
+	execWrapper execwrapper.ExecWrapper
 }
 
 // CPUBenchmarkResult holds CPU benchmark results with the workloads number during the benchmark.
@@ -28,11 +28,11 @@ var _ perf.Task = (*CPUBenchmarkTask)(nil)
 // NewTask returns a new CPU benchmark task.
 func NewTask() perf.Task {
 	return &CPUBenchmarkTask{
-		execWrapper: &iperf.RealExecWrapper{},
+		execWrapper: &execwrapper.RealExecWrapper{},
 	}
 }
 
-func NewTaskWithExecWrapper(execWrapper iperf.ExecWrapper) perf.Task {
+func NewTaskWithExecWrapper(execWrapper execwrapper.ExecWrapper) perf.Task {
 	return &CPUBenchmarkTask{
 		execWrapper: execWrapper,
 	}

--- a/pkg/perf/cpubench/cpubench_task.go
+++ b/pkg/perf/cpubench/cpubench_task.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"github.com/threefoldtech/zosbase/pkg/perf"
+	"github.com/threefoldtech/zosbase/pkg/perf/iperf" // Import for ExecWrapper
 	"github.com/threefoldtech/zosbase/pkg/stubs"
 )
 
 // CPUBenchmarkTask defines CPU benchmark task.
-type CPUBenchmarkTask struct{}
+type CPUBenchmarkTask struct {
+	execWrapper iperf.ExecWrapper
+}
 
 // CPUBenchmarkResult holds CPU benchmark results with the workloads number during the benchmark.
 type CPUBenchmarkResult struct {
@@ -25,7 +27,15 @@ var _ perf.Task = (*CPUBenchmarkTask)(nil)
 
 // NewTask returns a new CPU benchmark task.
 func NewTask() perf.Task {
-	return &CPUBenchmarkTask{}
+	return &CPUBenchmarkTask{
+		execWrapper: &iperf.RealExecWrapper{},
+	}
+}
+
+func NewTaskWithExecWrapper(execWrapper iperf.ExecWrapper) perf.Task {
+	return &CPUBenchmarkTask{
+		execWrapper: execWrapper,
+	}
 }
 
 // ID returns task ID.
@@ -50,7 +60,8 @@ func (c *CPUBenchmarkTask) Jitter() uint32 {
 
 // Run executes the CPU benchmark.
 func (c *CPUBenchmarkTask) Run(ctx context.Context) (interface{}, error) {
-	cpubenchOut, err := exec.CommandContext(ctx, "cpubench", "-j").CombinedOutput()
+	cmd := c.execWrapper.CommandContext(ctx, "cpubench", "-j")
+	cpubenchOut, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute cpubench command: %w", err)
 	}

--- a/pkg/perf/cpubench/cpubench_task_test.go
+++ b/pkg/perf/cpubench/cpubench_task_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zosbase/pkg/mocks"
 	"github.com/threefoldtech/zosbase/pkg/perf"
-	"github.com/threefoldtech/zosbase/pkg/perf/iperf"
+	execwrapper "github.com/threefoldtech/zosbase/pkg/perf/exec_wrapper"
 	"go.uber.org/mock/gomock"
 )
 
@@ -35,8 +35,8 @@ func TestCPUBenchmarkTask_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockExec := iperf.NewMockExecWrapper(ctrl)
-	mockCmd := iperf.NewMockExecCmd(ctrl)
+	mockExec := execwrapper.NewMockExecWrapper(ctrl)
+	mockCmd := execwrapper.NewMockExecCmd(ctrl)
 	task := NewTaskWithExecWrapper(mockExec).(*CPUBenchmarkTask)
 	ctx := context.Background()
 	mockZbus := mocks.NewMockClient(ctrl)

--- a/pkg/perf/cpubench/cpubench_task_test.go
+++ b/pkg/perf/cpubench/cpubench_task_test.go
@@ -1,0 +1,121 @@
+package cpubench
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/threefoldtech/zbus"
+	"github.com/threefoldtech/zosbase/pkg/mocks"
+	"github.com/threefoldtech/zosbase/pkg/perf"
+	"github.com/threefoldtech/zosbase/pkg/perf/iperf"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCPUBenchmarkTask(t *testing.T) {
+	t.Run("create new CPU benchmark task", func(t *testing.T) {
+		task := NewTask()
+
+		assert.NotNil(t, task)
+		assert.Equal(t, "cpu-benchmark", task.ID())
+		assert.Equal(t, "0 0 */6 * * *", task.Cron()) // Every 6 hours
+		assert.Contains(t, task.Description(), "CPU")
+		assert.Equal(t, uint32(0), task.Jitter())
+	})
+
+	t.Run("task implements perf.Task interface", func(t *testing.T) {
+		var _ perf.Task = NewTask()
+	})
+}
+
+func TestCPUBenchmarkTask_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockExec := iperf.NewMockExecWrapper(ctrl)
+	mockCmd := iperf.NewMockExecCmd(ctrl)
+	task := NewTaskWithExecWrapper(mockExec).(*CPUBenchmarkTask)
+	ctx := context.Background()
+	mockZbus := mocks.NewMockClient(ctrl)
+	ctx = perf.WithZbusClient(ctx, mockZbus)
+
+	mockExec.EXPECT().CommandContext(ctx, "cpubench", "-j").Return(mockCmd).Times(4)
+	t.Run("successful benchmark execution", func(t *testing.T) {
+
+		// Mock successful cpubench execution
+		expectedOutput := `{
+			"single": 1542.67,
+			"multi": 6170.89,
+			"threads": 4
+		}`
+
+		data := make([]byte, 8)
+		binary.LittleEndian.PutUint64(data, 5)
+		response := &zbus.Response{
+			ID: "test-id",
+			Output: zbus.Output{
+				Data:  data,
+				Error: nil,
+			},
+		}
+
+		mockZbus.EXPECT().
+			RequestContext(gomock.Any(), "provision", zbus.ObjectID{Name: "statistics", Version: "0.0.1"}, "Workloads").
+			Return(response, nil)
+
+		mockCmd.EXPECT().CombinedOutput().Return([]byte(expectedOutput), nil)
+
+		result, err := task.Run(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// Verify result structure
+		cpuResult, ok := result.(CPUBenchmarkResult)
+		require.True(t, ok, "Result should be of type CPUBenchmarkResult")
+
+		assert.Equal(t, 1542.67, cpuResult.SingleThreaded)
+		assert.Equal(t, 6170.89, cpuResult.MultiThreaded)
+		assert.Equal(t, 4, cpuResult.Threads)
+		assert.Equal(t, 5, cpuResult.Workloads)
+
+	})
+
+	t.Run("cpubench command fails", func(t *testing.T) {
+		// Mock command failure
+		mockCmd.EXPECT().CombinedOutput().Return([]byte{}, errors.New("command not found"))
+
+		result, err := task.Run(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to execute cpubench command")
+	})
+
+	t.Run("invalid JSON output", func(t *testing.T) {
+
+		// Mock command with invalid JSON output
+		invalidJSON := `{invalid json output}`
+
+		mockCmd.EXPECT().CombinedOutput().Return([]byte(invalidJSON), nil)
+
+		result, err := task.Run(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to parse cpubench output")
+	})
+
+	t.Run("failed to get workloads number", func(t *testing.T) {
+
+		mockCmd.EXPECT().CombinedOutput().Return([]byte(`{"single": 1000, "multi": 2000, "threads": 4}`), nil)
+		// Mock failure in getting workloads number
+		mockZbus.EXPECT().
+			RequestContext(gomock.Any(), "provision", zbus.ObjectID{Name: "statistics", Version: "0.0.1"}, "Workloads").
+			Return(nil, errors.New("failed to get workloads"))
+
+		assert.Panics(t, func() {
+			_, _ = task.Run(ctx)
+		})
+	})
+}

--- a/pkg/perf/exec_wrapper/exec_wrapper.go
+++ b/pkg/perf/exec_wrapper/exec_wrapper.go
@@ -1,4 +1,4 @@
-package iperf
+package execwrapper
 
 import (
 	"context"

--- a/pkg/perf/exec_wrapper/exec_wrapper.go
+++ b/pkg/perf/exec_wrapper/exec_wrapper.go
@@ -38,6 +38,3 @@ type RealExecCmd struct {
 func (r *RealExecCmd) CombinedOutput() ([]byte, error) {
 	return r.cmd.CombinedOutput()
 }
-
-// Global instance that can be overridden in tests
-var execWrapper ExecWrapper = &RealExecWrapper{}

--- a/pkg/perf/exec_wrapper/mock_exec_wrapper.go
+++ b/pkg/perf/exec_wrapper/mock_exec_wrapper.go
@@ -5,15 +5,14 @@
 //
 //	mockgen -source=pkg/perf/iperf/exec_wrapper.go -destination=pkg/perf/iperf/mock_exec_wrapper.go -package=iperf
 //
-
-// Package iperf is a generated GoMock package.
-package iperf
+// Package execwrapper is a generated GoMock package.
+package execwrapper
 
 import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
+	gomock "go.uber.org/mock/gomock"	
 )
 
 // MockExecWrapper is a mock of ExecWrapper interface.

--- a/pkg/perf/exec_wrapper/mock_exec_wrapper.go
+++ b/pkg/perf/exec_wrapper/mock_exec_wrapper.go
@@ -12,7 +12,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"	
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockExecWrapper is a mock of ExecWrapper interface.

--- a/pkg/perf/iperf/iperf_task.go
+++ b/pkg/perf/iperf/iperf_task.go
@@ -16,6 +16,7 @@ import (
 	"github.com/threefoldtech/zosbase/pkg/environment"
 	"github.com/threefoldtech/zosbase/pkg/network/iperf"
 	"github.com/threefoldtech/zosbase/pkg/perf"
+	"github.com/threefoldtech/zosbase/pkg/perf/exec_wrapper"
 	"github.com/threefoldtech/zosbase/pkg/perf/graphql"
 )
 
@@ -32,7 +33,7 @@ const (
 type IperfTest struct {
 	// Optional dependencies for testing
 	graphqlClient GraphQLClient
-	execWrapper   ExecWrapper
+	execWrapper   execwrapper.ExecWrapper
 }
 
 // IperfResult for iperf test results
@@ -170,7 +171,7 @@ func (t *IperfTest) runIperfTest(ctx context.Context, clientIP string, tcp bool)
 		opts = append(opts, "--length", "16B", "--udp")
 	}
 
-	execWrap := execWrapper
+	var execWrap execwrapper.ExecWrapper = &execwrapper.RealExecWrapper{}
 	if t.execWrapper != nil {
 		execWrap = t.execWrapper
 	}
@@ -221,7 +222,7 @@ func (t *IperfTest) runIperfTest(ctx context.Context, clientIP string, tcp bool)
 	return iperfResult
 }
 
-func runIperfCommand(ctx context.Context, opts []string, execWrap ExecWrapper) iperfCommandOutput {
+func runIperfCommand(ctx context.Context, opts []string, execWrap execwrapper.ExecWrapper) iperfCommandOutput {
 	output, err := execWrap.CommandContext(ctx, "iperf", opts...).CombinedOutput()
 	exitErr := &exec.ExitError{}
 	if err != nil && !errors.As(err, &exitErr) {

--- a/pkg/perf/iperf/iperf_task_test.go
+++ b/pkg/perf/iperf/iperf_task_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	execwrapper "github.com/threefoldtech/zosbase/pkg/perf/exec_wrapper"
 	"github.com/threefoldtech/zosbase/pkg/perf/graphql"
 	"go.uber.org/mock/gomock"
 )
@@ -16,8 +17,8 @@ func TestIperfTest_Run_Success(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGraphQL := NewMockGraphQLClient(ctrl)
-	mockExec := NewMockExecWrapper(ctrl)
-	mockCmd := NewMockExecCmd(ctrl)
+	mockExec := execwrapper.NewMockExecWrapper(ctrl)
+	mockCmd := execwrapper.NewMockExecCmd(ctrl)
 
 	task := &IperfTest{
 		graphqlClient: mockGraphQL,
@@ -111,7 +112,7 @@ func TestIperfTest_Run_IperfNotFound(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGraphQL := NewMockGraphQLClient(ctrl)
-	mockExec := NewMockExecWrapper(ctrl)
+	mockExec := execwrapper.NewMockExecWrapper(ctrl)
 
 	task := &IperfTest{
 		graphqlClient: mockGraphQL,
@@ -142,7 +143,7 @@ func TestIperfTest_Run_InvalidIPAddress(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockGraphQL := NewMockGraphQLClient(ctrl)
-	mockExec := NewMockExecWrapper(ctrl)
+	mockExec := execwrapper.NewMockExecWrapper(ctrl)
 
 	task := &IperfTest{
 		graphqlClient: mockGraphQL,


### PR DESCRIPTION
### Description

moved execwrapper to exec_wrapper to be common between cpubench and iperf

### Changes

### Related Issues

https://github.com/threefoldtech/zos/issues/2465

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
