### PR TITLE
use consistent name for v4hub_urls

### DIFF
--- a/pkg/environment/config.go
+++ b/pkg/environment/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	GeoipURLs     []string `json:"geoip_urls"`
 
 	HubURL   []string `json:"hub_urls"`
-	V4HubURL []string `json:"v4_hub_urls"`
+	V4HubURL []string `json:"v4hub_urls"`
 
 	// we should not be supporting flist url or hub storage from zos-config until we can update them on runtime
 	FlistURL     string `json:"flist_url"`


### PR DESCRIPTION
### Description
we use v4hub_urls in bootstrap but someone decided to use it v4_hub_urls here which will break the env or bootstrap 
https://github.com/threefoldtech/zos4/blob/main/bootstrap/bootstrap/src/hub.rs#L14

### Changes

List of changes this PR includes

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
