### PR TITLE
extract vmCheck into separate task

### DIFF
--- a/pkg/perf/healthcheck/healthcheck.go
+++ b/pkg/perf/healthcheck/healthcheck.go
@@ -25,7 +25,6 @@ func NewTask() perf.Task {
 	checks := map[string]checkFunc{
 		"cache":   cacheCheck,
 		"network": networkCheck,
-		"vm":      vmCheck,
 	}
 	return &healthcheckTask{
 		checks: checks,

--- a/pkg/perf/provisiontest/provisiontest.go
+++ b/pkg/perf/provisiontest/provisiontest.go
@@ -1,0 +1,87 @@
+package provisiontest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/zosbase/pkg/perf"
+	"github.com/threefoldtech/zosbase/pkg/stubs"
+)
+
+const (
+	id          = "provisiontest"
+	schedule    = "0 0 0 * * *"
+	description = "daily provision test that deploys a test VM to verify the node can run virtual machines and sets flags for the power daemon"
+)
+
+type provisionTestTask struct{}
+
+var _ perf.Task = (*provisionTestTask)(nil)
+
+func NewTask() perf.Task {
+	return &provisionTestTask{}
+}
+
+func (t *provisionTestTask) ID() string {
+	return id
+}
+
+func (t *provisionTestTask) Cron() string {
+	return schedule
+}
+
+func (t *provisionTestTask) Description() string {
+	return description
+}
+
+func (t *provisionTestTask) Jitter() uint32 {
+	return 30 * 60
+}
+
+func (t *provisionTestTask) Run(ctx context.Context) (interface{}, error) {
+	log.Debug().Msg("starting provision test task")
+
+	cl := perf.MustGetZbusClient(ctx)
+	zui := stubs.NewZUIStub(cl)
+
+	var result []string
+
+	op := func() error {
+		errs := vmCheck(ctx)
+		result = errorsToStrings(errs)
+
+		if err := zui.PushErrors(ctx, "vm", result); err != nil {
+			return err
+		}
+
+		if len(errs) != 0 {
+			return fmt.Errorf("provision test failed: %s", result)
+		}
+
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		log.Error().Err(err).Dur("retry-in", t).Msg("failed provision test. retrying")
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 3 * time.Minute
+	bo.MaxInterval = 30 * time.Second
+	bo.MaxElapsedTime = 10 * time.Minute
+
+	_ = backoff.RetryNotify(op, bo, notify)
+
+	return result, nil
+}
+
+func errorsToStrings(errs []error) []string {
+	s := make([]string, 0, len(errs))
+	for _, err := range errs {
+		s = append(s, err.Error())
+	}
+	return s
+}

--- a/pkg/perf/provisiontest/vm.go
+++ b/pkg/perf/provisiontest/vm.go
@@ -1,4 +1,4 @@
-package healthcheck
+package provisiontest
 
 import (
 	"context"


### PR DESCRIPTION
This test was extracted from the general healthcheck task (which ran every 15 minutes) because the VMD module uses a single mutex to serialize all VM operations (Run, Delete, Monitor).
Running a full VM deploy+wait+delete cycle every 15 minutes kept the VMD lock occupied too often blocking real user deployments and causing timeouts. A daily schedule is sufficient to verify the node's virtualization capability without starving actual workloads